### PR TITLE
[Updated: should be fixed. please squash commits to latest when merging] Component endpoints

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -43,7 +43,8 @@ var getTags = (id, callback) => {
     });
 };
 
-// for testing only
+// for testing or whatev
+// Not used in FEC implementation
 var getAllTrails = (callback) => {
   knex.select()
     .from('trail')

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "axios": "^0.18.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jest-cli": "^23.6.0",
     "lorem-ipsum": "^1.0.6",
     "morgan": "^1.9.1",
+    "nodemon": "^1.18.9",
     "style-loader": "^0.23.0",
     "supertest": "^3.3.0",
     "webpack": "^4.19.1",

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,8 @@ app.use(morgan('dev'));
 // http://localhost:3001
 app.use(express.static(__dirname + '/../public'));
 
-// to test sending all rows from trail table
+// If, for whatever reason you need to test getting & sending all rows from
+// the trail db table:
 // app.get('/', (req, res) => {
 //   db.getAllTrails( (rowsRes) => {
 //     res.json(rowsRes);
@@ -35,15 +36,16 @@ app.get('/:trailId/trailInfo', cors(), (req, res) => {
     // see example-data.json for example
     var theTrail = row[0];
     var resObj = {};
-    resObj.data = {};
-    resObj.data.attributes = {};
+    resObj.data = {
+      attributes: {}
+    };
     for (var prop in theTrail) {
       if (prop === 'trail_id') {
         resObj.data['id'] = theTrail['trail_id'].toString();
       } else {
-        resObj.data.type = 'trail';
         resObj.data.attributes[prop] = row[0][prop];
       }
+      resObj.data.type = 'trail';
     }
     db.getTags(theId, (tags) => {
       resObj.data.attributes.tags = tags;

--- a/server/index.js
+++ b/server/index.js
@@ -44,7 +44,7 @@ app.get('/:trailId/trailInfo', cors(), (req, res) => {
       if (prop === 'trail_id') {
         resObj.data['id'] = theTrail['trail_id'].toString();
       } else {
-        resObj.data.attributes[prop] = row[0][prop];
+        resObj.data.attributes[prop] = theTrail[prop];
       }
       resObj.data.type = 'trail';
     }
@@ -57,8 +57,6 @@ app.get('/:trailId/trailInfo', cors(), (req, res) => {
 
 /*
   API endpoint for trail service Banner component state
-  Example response: {"trailId":1,"trailName":"Golden Gate Park
-  Trail","difficulty":"Easy","rank":"#11 ranked trail out of 20"}
 */
 app.get('/:trailId/banner', cors(), (req, res) => {
   var theId = req.params.trailId;
@@ -77,6 +75,29 @@ app.get('/:trailId/banner', cors(), (req, res) => {
       resObj.trailRank = bannerRes.rank;
       resObj.heroUrl = bannerRes.heroUrl;
       resObj.photosCount = bannerRes.count;
+      res.status(200).json(resObj);
+    });
+  });
+});
+
+/*
+  API endpoint for trail service TrailDescription component state
+*/
+app.get('/:trailId/trailDescription', cors(), (req, res) => {
+  var theId = req.params.trailId;
+  db.getTrail(theId, (row) => {
+    // trail object for response to trailDescription component
+    var theTrail = row[0];
+    var resObj = {
+      description: theTrail.description,
+      distance: theTrail.distance,
+      distanceUnits: theTrail.distance_units,
+      elevationGain: theTrail.elevation_gain,
+      elevationUnits: theTrail.elevation_units,
+      routeType: theTrail.route_type,
+    };
+    db.getTags(theId, (tags) => {
+      resObj.tags = tags;
       res.status(200).json(resObj);
     });
   });

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const db = require('../database/index');
+const service = require('./serviceHelpers');
 const morgan = require('morgan');
 
 const app = express();
@@ -49,7 +50,34 @@ app.get('/:trailId/trailInfo', cors(), (req, res) => {
     }
     db.getTags(theId, (tags) => {
       resObj.data.attributes.tags = tags;
-      res.status(200).send(resObj);
+      res.status(200).json(resObj);
+    });
+  });
+});
+
+/*
+  API endpoint for trail service Banner component state
+  Example response: {"trailId":1,"trailName":"Golden Gate Park
+  Trail","difficulty":"Easy","rank":"#11 ranked trail out of 20"}
+*/
+app.get('/:trailId/banner', cors(), (req, res) => {
+  var theId = req.params.trailId;
+  db.getTrail(theId, (row) => {
+    var theTrail = row[0];
+    // banner state only needs trailName and difficulty from trail-service
+    var resObj = {
+      trailId: theTrail.trail_id,
+      trailName: theTrail.trail_name,
+      difficulty: theTrail.difficulty
+    };
+    // banner state data from reviews and trail-photos services
+    service.getBannerData(theId, (bannerRes) => {
+      resObj.totalReviews = bannerRes.stats.totalReviews;
+      resObj.avgRating = bannerRes.stats.avgRating;
+      resObj.trailRank = bannerRes.rank;
+      resObj.heroUrl = bannerRes.heroUrl;
+      resObj.photosCount = bannerRes.count;
+      res.status(200).json(resObj);
     });
   });
 });

--- a/server/serviceHelpers.js
+++ b/server/serviceHelpers.js
@@ -6,6 +6,21 @@ const servicePorts = {
   PHOTOS: '3003'
 };
 
+// getBannerData axios functions for multiple concurrent requests
+// https://www.npmjs.com/package/axios#example
+var getTrailStats = (endpoint) => {
+  return axios.get(endpoint);
+};
+var getTrailRank = (endpoint) => {
+  return axios.get(endpoint);
+};
+var getHeroPhoto = (endpoint) => {
+  return axios.get(endpoint);
+};
+var getPhotosCount = (endpoint) => {
+  return axios.get(endpoint);
+};
+
 // get data from reviews-service and trail-photos-service for the Banner
 // component endpoint
 var getBannerData = (id, callback) => {
@@ -15,40 +30,21 @@ var getBannerData = (id, callback) => {
   var heroPhoto = `http://localhost:${servicePorts.PHOTOS}/${id}/heroPhoto`;
   var photosCount = `http://localhost:${servicePorts.PHOTOS}/${id}/photosCount`;
 
-  axios.get(trailStats)
-    .then((response) => {
-      result.stats = response.data;
-    })
-    .catch((error) => {
-      console.error('axios.get trailStats: ', error);
-    });
-
-  axios.get(trailRank)
-    .then((rankResponse) => {
-      result.rank = rankResponse.data;
-    })
-    .catch((err) => {
-      console.error('axios.get trailRank: ', err);
-    });
-
-  axios.get(heroPhoto)
-    .then((heroResponse) => {
-      result.heroUrl = heroResponse.data.data.attributes.photo_url;
-      console.log('heroUrl: ', heroResponse.data.data.attributes.photo_url);
-    })
-    .catch((err) => {
-      console.error('axios.get heroPhoto: ', err);
-    });
-
-  axios.get(photosCount)
-    .then((countResponse) => {
-      result.count = countResponse.data.data.attributes.count;
-      callback(result);
-      console.log('photosCount: ', countResponse.data.data.attributes.count);
-    })
-    .catch((err) => {
-      console.error('axios.get photosCount: ', err);
-    });
+  axios.all([
+    getTrailStats(trailStats),
+    getTrailRank(trailRank),
+    getHeroPhoto(heroPhoto),
+    getPhotosCount(photosCount)
+  ]).then(axios.spread(function (tStats, tRank, hPhoto, pCount) {
+    // all requests should be complete
+    result.stats = tStats.data;
+    result.rank = tRank.data;
+    result.heroUrl = hPhoto.data.data.attributes.photo_url;
+    result.count = pCount.data.data.attributes.count;
+    callback(result);
+  })).catch((error) => {
+    console.error('axios.all catch: ', error);
+  });
 };
 
 module.exports.getBannerData = getBannerData;

--- a/server/serviceHelpers.js
+++ b/server/serviceHelpers.js
@@ -1,0 +1,54 @@
+var axios = require('axios');
+
+// service ports TODO: move to config file
+const servicePorts = {
+  REVIEWS: '3004',
+  PHOTOS: '3003'
+};
+
+// get data from reviews-service and trail-photos-service for the Banner
+// component endpoint
+var getBannerData = (id, callback) => {
+  var result = {};
+  var trailStats = `http://localhost:${servicePorts.REVIEWS}/${id}/trailStats`;
+  var trailRank = `http://localhost:${servicePorts.REVIEWS}/${id}/trailRank`;
+  var heroPhoto = `http://localhost:${servicePorts.PHOTOS}/${id}/heroPhoto`;
+  var photosCount = `http://localhost:${servicePorts.PHOTOS}/${id}/photosCount`;
+
+  axios.get(trailStats)
+    .then((response) => {
+      result.stats = response.data;
+    })
+    .catch((error) => {
+      console.error('axios.get trailStats: ', error);
+    });
+
+  axios.get(trailRank)
+    .then((rankResponse) => {
+      result.rank = rankResponse.data;
+    })
+    .catch((err) => {
+      console.error('axios.get trailRank: ', err);
+    });
+
+  axios.get(heroPhoto)
+    .then((heroResponse) => {
+      result.heroUrl = heroResponse.data.data.attributes.photo_url;
+      console.log('heroUrl: ', heroResponse.data.data.attributes.photo_url);
+    })
+    .catch((err) => {
+      console.error('axios.get heroPhoto: ', err);
+    });
+
+  axios.get(photosCount)
+    .then((countResponse) => {
+      result.count = countResponse.data.data.attributes.count;
+      callback(result);
+      console.log('photosCount: ', countResponse.data.data.attributes.count);
+    })
+    .catch((err) => {
+      console.error('axios.get photosCount: ', err);
+    });
+};
+
+module.exports.getBannerData = getBannerData;


### PR DESCRIPTION
- [x] Add api endpoint for each of my widgets `Banner` and `TrailDescription`

* When running the `trail-service`, `trail-photos-service`, and `reviews-service` locally, requests to these endpoints return responses shaped for each component state:
    - `http://localhost:3001/1/banner`
    - `http://localhost:3001/1/trailDescription`

@MengRS or @weber93 - if you could review & merge when you get a chance? Thanks!